### PR TITLE
Fix const warning in latest compiler

### DIFF
--- a/requests.inc
+++ b/requests.inc
@@ -240,7 +240,7 @@ native JsonToggleGC(Node:node, bool:toggle);
 native JsonCleanup(Node:node, auto = false);
 
 // cleans up nodes once they go out of scope.
-stock operator~(Node:nodes[], len) {
+stock operator~(const Node:nodes[], len) {
     for(new i; i < len; ++i) {
         JsonCleanup(nodes[i], true);
     }


### PR DESCRIPTION
Fixes this warning:
```
requests.inc:243 (warning) possibly a "const" array argument was intended: "nodes"
```