### PR TITLE
added an AMX* property to callback events

### DIFF
--- a/src/impl.cpp
+++ b/src/impl.cpp
@@ -37,7 +37,7 @@ int Impl::RequestHeaders(std::vector<std::pair<std::string, std::string>> header
 int Impl::Request(AMX* amx, int id, std::string path, E_HTTP_METHOD method, std::string callback, char* data, int headers)
 {
     RequestData requestData;
-	requestData.amx = amx;
+    requestData.amx = amx;
     requestData.id = requestCounter;
     requestData.callback = callback;
     requestData.path = path;
@@ -56,7 +56,7 @@ int Impl::Request(AMX* amx, int id, std::string path, E_HTTP_METHOD method, std:
 int Impl::RequestJSON(AMX* amx, int id, std::string path, E_HTTP_METHOD method, std::string callback, web::json::value json, int headers)
 {
     RequestData requestData;
-	requestData.amx = amx;
+    requestData.amx = amx;
     requestData.id = requestCounter;
     requestData.callback = callback;
     requestData.path = path;
@@ -100,7 +100,7 @@ int Impl::doRequest(int id, RequestData requestData)
 void Impl::doRequestWithClient(ClientData cd, RequestData requestData)
 {
     ResponseData responseData;
-	responseData.amx = requestData.amx;
+    responseData.amx = requestData.amx;
     responseData.id = requestData.id;
     responseData.callback = requestData.callback;
     responseData.responseType = E_CONTENT_TYPE::empty;

--- a/src/impl.cpp
+++ b/src/impl.cpp
@@ -34,9 +34,10 @@ int Impl::RequestHeaders(std::vector<std::pair<std::string, std::string>> header
     return id;
 }
 
-int Impl::Request(int id, std::string path, E_HTTP_METHOD method, std::string callback, char* data, int headers)
+int Impl::Request(AMX* amx, int id, std::string path, E_HTTP_METHOD method, std::string callback, char* data, int headers)
 {
     RequestData requestData;
+	requestData.amx = amx;
     requestData.id = requestCounter;
     requestData.callback = callback;
     requestData.path = path;
@@ -52,9 +53,10 @@ int Impl::Request(int id, std::string path, E_HTTP_METHOD method, std::string ca
     return requestCounter++;
 }
 
-int Impl::RequestJSON(int id, std::string path, E_HTTP_METHOD method, std::string callback, web::json::value json, int headers)
+int Impl::RequestJSON(AMX* amx, int id, std::string path, E_HTTP_METHOD method, std::string callback, web::json::value json, int headers)
 {
     RequestData requestData;
+	requestData.amx = amx;
     requestData.id = requestCounter;
     requestData.callback = callback;
     requestData.path = path;
@@ -98,6 +100,7 @@ int Impl::doRequest(int id, RequestData requestData)
 void Impl::doRequestWithClient(ClientData cd, RequestData requestData)
 {
     ResponseData responseData;
+	responseData.amx = requestData.amx;
     responseData.id = requestData.id;
     responseData.callback = requestData.callback;
     responseData.responseType = E_CONTENT_TYPE::empty;

--- a/src/impl.hpp
+++ b/src/impl.hpp
@@ -9,6 +9,7 @@
 #include <cpprest/json.h>
 #include <cpprest/ws_client.h>
 
+#include <amx/amx2.h>
 #include "common.hpp"
 
 using namespace utility; // Common utilities like string conversions
@@ -39,6 +40,7 @@ enum E_CONTENT_TYPE {
     json
 };
 struct RequestData {
+	AMX* amx;
     int id;
     std::string callback;
     std::string path;
@@ -49,6 +51,7 @@ struct RequestData {
     web::json::value bodyJson;
 };
 struct ResponseData {
+	AMX* amx;
     int id;
     std::string callback;
     int status;
@@ -59,8 +62,8 @@ struct ResponseData {
 
 int RequestsClient(std::string endpoint, int headers);
 int RequestHeaders(std::vector<std::pair<std::string, std::string>> headers);
-int Request(int id, std::string path, E_HTTP_METHOD method, std::string callback, char* data, int headers);
-int RequestJSON(int id, std::string path, E_HTTP_METHOD method, std::string callback, web::json::value json, int headers);
+int Request(AMX* amx, int id, std::string path, E_HTTP_METHOD method, std::string callback, char* data, int headers);
+int RequestJSON(AMX* amx, int id, std::string path, E_HTTP_METHOD method, std::string callback, web::json::value json, int headers);
 
 int WebSocketClient(std::string address, std::string callback);
 int WebSocketSend(int id, std::string data);

--- a/src/impl.hpp
+++ b/src/impl.hpp
@@ -9,8 +9,8 @@
 #include <cpprest/json.h>
 #include <cpprest/ws_client.h>
 
-#include <amx/amx2.h>
 #include "common.hpp"
+#include <amx/amx2.h>
 
 using namespace utility; // Common utilities like string conversions
 using namespace web; // Common features like URIs.
@@ -40,7 +40,7 @@ enum E_CONTENT_TYPE {
     json
 };
 struct RequestData {
-	AMX* amx;
+    AMX* amx;
     int id;
     std::string callback;
     std::string path;
@@ -51,7 +51,7 @@ struct RequestData {
     web::json::value bodyJson;
 };
 struct ResponseData {
-	AMX* amx;
+    AMX* amx;
     int id;
     std::string callback;
     int status;

--- a/src/natives.cpp
+++ b/src/natives.cpp
@@ -57,9 +57,9 @@ void Natives::processTick(AMX* amx)
 {
     std::vector<Impl::ResponseData> responses = Impl::gatherResponses();
     for (auto response : responses) {
-		if (response.amx != amx) {
-			continue;
-		}
+        if (response.amx != amx) {
+            continue;
+        }
 
         int error;
         int amx_idx;

--- a/src/natives.cpp
+++ b/src/natives.cpp
@@ -38,7 +38,7 @@ int Natives::Request(AMX* amx, cell* params)
     // std::string data = amx_GetCppString(amx, params[6]);
     int headers = params[6];
 
-    return Impl::Request(id, path, method, callback, data, headers);
+    return Impl::Request(amx, id, path, method, callback, data, headers);
 }
 
 int Natives::RequestJSON(AMX* amx, cell* params)
@@ -50,13 +50,17 @@ int Natives::RequestJSON(AMX* amx, cell* params)
     auto obj = JSON::Get(params[5]);
     int headers = params[6];
 
-    return Impl::RequestJSON(id, path, method, callback, obj, headers);
+    return Impl::RequestJSON(amx, id, path, method, callback, obj, headers);
 }
 
 void Natives::processTick(AMX* amx)
 {
     std::vector<Impl::ResponseData> responses = Impl::gatherResponses();
     for (auto response : responses) {
+		if (response.amx != amx) {
+			continue;
+		}
+
         int error;
         int amx_idx;
         cell amx_addr;


### PR DESCRIPTION
This change addresses #20 by providing a way of associating RequestData
and ResponseData objects to specific AMX instances. Unfortunately this
breaks the isolation of impl.* files from AMX and SA:MP related code but
it's a necessary change. When a request is created, the address of the
AMX it is called from is stored into the request object which is then
passed on to the response object when the request has finished. During
the processTick function, each queued responses' AMX address is then
checked against the AMX that called processTick to ensure no duplicate
events are dispatched to AMX instances.