### PR TITLE
Set default value for isWebSocket to 0

### DIFF
--- a/src/impl.hpp
+++ b/src/impl.hpp
@@ -57,7 +57,7 @@ struct ResponseData {
     int status;
     E_CONTENT_TYPE responseType;
     std::string rawBody;
-    bool isWebSocket;
+    bool isWebSocket = 0;
 };
 
 int RequestsClient(std::string endpoint, int headers);

--- a/src/impl.hpp
+++ b/src/impl.hpp
@@ -57,7 +57,7 @@ struct ResponseData {
     int status;
     E_CONTENT_TYPE responseType;
     std::string rawBody;
-    bool isWebSocket = 0;
+    bool isWebSocket = false;
 };
 
 int RequestsClient(std::string endpoint, int headers);


### PR DESCRIPTION
As I described in Discord.
For my request `https://api.vk.com/method/messages.send?v=5.41&access_token=0aeefb9ef7a13cb2090a1151057348a940577ebad2fca2a6e6b8c6361302907daff5b0a5efa9db0e662ab&message=hello+world&user_id=31133244`
I got this results:
```
id = 0 | status = 1717044
dataLen = 0
```
with this code:
```Pawn
gVkClient = RequestsClient("https://api.vk.com/method/");
Request(gVkClient, request, HTTP_METHOD_POST, "VK_OnSend");

forward VK_OnSend(Request:id, E_HTTP_STATUS:status, data[], dataLen);
public VK_OnSend(Request:id, E_HTTP_STATUS:status, data[], dataLen)
{
    printf("id = %d | status = %d", _:id, _:status);
    printf("dataLen = %d", dataLen);
    for (new i = 0; i < dataLen; i++) {
        printf("data[%d] = %c | %d", i, data[i], data[i]);
    }
    printf(data);
    return 0;
}
```
After some research, I found the mistake: `isWebSocket` have no init, so, by default it can be with any value. And this small PR fixes it.