### PR TITLE
fix deprecated syntax for trait objects

### DIFF
--- a/src/request_client.rs
+++ b/src/request_client.rs
@@ -33,7 +33,7 @@ impl RequestClient {
         amx: AsyncAmx,
         endpoint: String,
         headers: HeaderMap,
-    ) -> Result<RequestClient, Box<std::error::Error>> {
+    ) -> Result<RequestClient, Box<dyn std::error::Error>> {
         let url = url::Url::parse(&endpoint)?;
         if !url.scheme().starts_with("http") {
             return Err(static_err("non-http scheme"));
@@ -54,7 +54,7 @@ impl RequestClient {
         &mut self,
         request: Request,
         json_nodes: Option<Arc<Mutex<GarbageCollectedPool<serde_json::Value>>>>,
-    ) -> Result<i32, Box<Error>> {
+    ) -> Result<i32, Box<dyn Error>> {
         let id = self.request_id;
         let mut full_url = self.endpoint.clone();
         let response_amx = self.amx.clone();


### PR DESCRIPTION
Trait objects without explicit `dyn` is now deprecated in  Rust >= 1.27