### PR TITLE
Ability to designate type of response

### DIFF
--- a/requests.inc
+++ b/requests.inc
@@ -12,7 +12,12 @@
 #include "status_codes"
 #include "http_methods"
 
-
+enum ResponseType
+{
+    RESPONSE_NONE = 0,
+    RESPONSE_STRING,
+    RESPONSE_JSON,
+};
 // -
 // Request API
 // -
@@ -39,7 +44,8 @@ native Request:Request(
     E_HTTP_METHOD:method,
     const callback[],
     body[] = "",
-    Headers:headers = Headers:-1
+    Headers:headers = Headers:-1,
+    ResponseType: response = RESPONSE_STRING
 );
 
 // RequestJSON performs a request to send or receive JSON data
@@ -49,7 +55,8 @@ native Request:RequestJSON(
     E_HTTP_METHOD:method,
     const callback[],
     Node:json = Node:-1,
-    Headers:headers = Headers:-1
+    Headers:headers = Headers:-1,
+    ResponseType: response = RESPONSE_JSON
 );
 
 // WebSocketClient creates a websocket client and establishes a connection at

--- a/src/impl.cpp
+++ b/src/impl.cpp
@@ -34,7 +34,7 @@ int Impl::RequestHeaders(std::vector<std::pair<std::string, std::string>> header
     return id;
 }
 
-int Impl::Request(AMX* amx, int id, std::string path, E_HTTP_METHOD method, std::string callback, char* data, int headers)
+int Impl::Request(AMX* amx, int id, std::string path, E_HTTP_METHOD method, std::string callback, char* data, int headers, E_CONTENT_TYPE response_type)
 {
     RequestData requestData;
     requestData.amx = amx;
@@ -42,7 +42,7 @@ int Impl::Request(AMX* amx, int id, std::string path, E_HTTP_METHOD method, std:
     requestData.callback = callback;
     requestData.path = path;
     requestData.method = method;
-    requestData.requestType = E_CONTENT_TYPE::string;
+    requestData.requestType = response_type;
     requestData.headers = headers;
     requestData.bodyString = data;
 
@@ -53,7 +53,7 @@ int Impl::Request(AMX* amx, int id, std::string path, E_HTTP_METHOD method, std:
     return requestCounter++;
 }
 
-int Impl::RequestJSON(AMX* amx, int id, std::string path, E_HTTP_METHOD method, std::string callback, web::json::value json, int headers)
+int Impl::RequestJSON(AMX* amx, int id, std::string path, E_HTTP_METHOD method, std::string callback, web::json::value json, int headers, E_CONTENT_TYPE response_type)
 {
     RequestData requestData;
     requestData.amx = amx;
@@ -61,7 +61,7 @@ int Impl::RequestJSON(AMX* amx, int id, std::string path, E_HTTP_METHOD method, 
     requestData.callback = callback;
     requestData.path = path;
     requestData.method = method;
-    requestData.requestType = E_CONTENT_TYPE::json;
+    requestData.requestType = response_type;
     requestData.headers = headers;
     requestData.bodyJson = json;
 

--- a/src/impl.cpp
+++ b/src/impl.cpp
@@ -42,7 +42,8 @@ int Impl::Request(AMX* amx, int id, std::string path, E_HTTP_METHOD method, std:
     requestData.callback = callback;
     requestData.path = path;
     requestData.method = method;
-    requestData.requestType = response_type;
+    requestData.requestType = E_CONTENT_TYPE::string;
+    requestData.responseType = response_type;
     requestData.headers = headers;
     requestData.bodyString = data;
 
@@ -61,7 +62,8 @@ int Impl::RequestJSON(AMX* amx, int id, std::string path, E_HTTP_METHOD method, 
     requestData.callback = callback;
     requestData.path = path;
     requestData.method = method;
-    requestData.requestType = response_type;
+    requestData.requestType = E_CONTENT_TYPE::json;
+    requestData.responseType = response_type;
     requestData.headers = headers;
     requestData.bodyJson = json;
 
@@ -170,7 +172,7 @@ void Impl::doRequestSync(ClientData cd, RequestData requestData, ResponseData& r
 
     responseData.status = response.status_code();
     responseData.rawBody = body;
-    responseData.responseType = requestData.requestType;
+    responseData.responseType = requestData.responseType;
 }
 
 web::http::method Impl::methodName(E_HTTP_METHOD id)

--- a/src/impl.cpp
+++ b/src/impl.cpp
@@ -130,7 +130,6 @@ void Impl::doRequestWithClient(ClientData cd, RequestData requestData)
         }
     }
     responseQueueLock.lock();
-    logprintf("Pushing response...");
     responseQueue.push(responseData);
     responseQueueLock.unlock();
 }
@@ -169,7 +168,6 @@ Impl::ResponseData Impl::doRequestSync(ClientData cd, RequestData requestData)
     }
     }
 
-    logprintf("Trying to get response...");
     http_response response = cd.client->request(request).get();
     std::string body = response.extract_utf8string().get();
 

--- a/src/impl.hpp
+++ b/src/impl.hpp
@@ -46,6 +46,7 @@ struct RequestData {
     std::string path;
     E_HTTP_METHOD method;
     E_CONTENT_TYPE requestType;
+    E_CONTENT_TYPE responseType;
     int headers;
     std::string bodyString;
     web::json::value bodyJson;

--- a/src/impl.hpp
+++ b/src/impl.hpp
@@ -62,8 +62,8 @@ struct ResponseData {
 
 int RequestsClient(std::string endpoint, int headers);
 int RequestHeaders(std::vector<std::pair<std::string, std::string>> headers);
-int Request(AMX* amx, int id, std::string path, E_HTTP_METHOD method, std::string callback, char* data, int headers);
-int RequestJSON(AMX* amx, int id, std::string path, E_HTTP_METHOD method, std::string callback, web::json::value json, int headers);
+int Request(AMX* amx, int id, std::string path, E_HTTP_METHOD method, std::string callback, char* data, int headers, E_CONTENT_TYPE response_type);
+int RequestJSON(AMX* amx, int id, std::string path, E_HTTP_METHOD method, std::string callback, web::json::value json, int headers, E_CONTENT_TYPE response_type);
 
 int WebSocketClient(std::string address, std::string callback);
 int WebSocketSend(int id, std::string data);

--- a/src/impl.hpp
+++ b/src/impl.hpp
@@ -1,8 +1,8 @@
 #include <stack>
 #include <string>
-#include <thread>
 #include <utility>
 #include <vector>
+#include <unordered_set>
 
 #include <cpprest/filestream.h>
 #include <cpprest/http_client.h>
@@ -85,7 +85,7 @@ struct WebSocketClientData {
 int headersCleanup(int id);
 int doRequest(int id, RequestData data);
 void doRequestWithClient(ClientData cd, RequestData requestData);
-void doRequestSync(ClientData cd, RequestData requestData, ResponseData& responseData);
+Impl::ResponseData doRequestSync(ClientData cd, RequestData requestData);
 web::http::method methodName(E_HTTP_METHOD id);
 void startWebSocketListener(WebSocketClientData wsc);
 

--- a/src/natives.cpp
+++ b/src/natives.cpp
@@ -37,8 +37,9 @@ int Natives::Request(AMX* amx, cell* params)
     amx_GetCString(amx, params[5], data);
     // std::string data = amx_GetCppString(amx, params[6]);
     int headers = params[6];
+    Impl::E_CONTENT_TYPE response_type =  static_cast<Impl::E_CONTENT_TYPE>(params[7]);
 
-    return Impl::Request(amx, id, path, method, callback, data, headers);
+    return Impl::Request(amx, id, path, method, callback, data, headers, response_type);
 }
 
 int Natives::RequestJSON(AMX* amx, cell* params)
@@ -49,8 +50,9 @@ int Natives::RequestJSON(AMX* amx, cell* params)
     std::string callback = amx_GetCppString(amx, params[4]);
     auto obj = JSON::Get(params[5]);
     int headers = params[6];
+    Impl::E_CONTENT_TYPE response_type =  static_cast<Impl::E_CONTENT_TYPE>(params[7]);
 
-    return Impl::RequestJSON(amx, id, path, method, callback, obj, headers);
+    return Impl::RequestJSON(amx, id, path, method, callback, obj, headers, response_type);
 }
 
 void Natives::processTick(AMX* amx)

--- a/src/natives.cpp
+++ b/src/natives.cpp
@@ -145,7 +145,6 @@ void Natives::processTick(const std::unordered_set<AMX*>& amxList)
                 break;
             }
         }
-        logprintf("Log: Response should have been sent. ");
     }
 }
 

--- a/src/natives.hpp
+++ b/src/natives.hpp
@@ -1,7 +1,7 @@
 #ifndef REQUESTS_NATIVES_H
 #define REQUESTS_NATIVES_H
 
-#include <set>
+#include <unordered_set>
 #include <string>
 #include <utility>
 
@@ -22,7 +22,7 @@ int WebSocketSend(AMX* amx, cell* params);
 int JsonWebSocketClient(AMX* amx, cell* params);
 int JsonWebSocketSend(AMX* amx, cell* params);
 
-void processTick(AMX* amx);
+void processTick(const std::unordered_set<AMX*>& amx);
 
 namespace JSON {
     int Parse(AMX* amx, cell* params);

--- a/src/requests.cpp
+++ b/src/requests.cpp
@@ -1,4 +1,4 @@
-#include <set>
+#include <unordered_set>
 
 #include <amx/amx.h>
 #include <plugincommon.h>
@@ -55,7 +55,7 @@ extern "C" AMX_NATIVE_INFO amx_Natives[] = {
     { 0, 0 }
 };
 
-std::set<AMX*> amx_List;
+std::unordered_set<AMX*> amx_List;
 
 PLUGIN_EXPORT unsigned int PLUGIN_CALL Supports()
 {
@@ -79,9 +79,7 @@ PLUGIN_EXPORT int PLUGIN_CALL AmxLoad(AMX* amx)
 
 PLUGIN_EXPORT void PLUGIN_CALL ProcessTick()
 {
-    for (AMX* i : amx_List) {
-        Natives::processTick(i);
-    }
+    Natives::processTick(amx_List);
 }
 
 PLUGIN_EXPORT int PLUGIN_CALL Unload()


### PR DESCRIPTION
Although a rare scenario, I encountered an issue while integrating the XenForo API with my server. The API for some reason has a data imparity where it demands a query string, however returns data in JSON. I tried to circumvent this by using the encode native, but that would just crash the server. 