### PR TITLE
fix: treat empty JSON response body as null node (#57)

### DIFF
--- a/src/natives.cpp
+++ b/src/natives.cpp
@@ -138,15 +138,24 @@ void Natives::processTick(std::set<AMX *> amx_List)
         case Impl::E_CONTENT_TYPE::json:
         {
             cell id = -1;
-            try
+            // empty body is a valid response so treat it as null json
+            if (response.rawBody.empty())
             {
-                json::value *obj = new json::value;
-                *obj = json::value::parse(utility::conversions::to_string_t(response.rawBody));
+                json::value *obj = new json::value(json::value::null());
                 id = JSON::Alloc(obj);
             }
-            catch (std::exception e)
+            else
             {
-                logprintf("ERROR: failed to parse response as JSON: '%s'", response.rawBody.c_str());
+                try
+                {
+                    json::value *obj = new json::value;
+                    *obj = json::value::parse(utility::conversions::to_string_t(response.rawBody));
+                    id = JSON::Alloc(obj);
+                }
+                catch (std::exception e)
+                {
+                    logprintf("ERROR: failed to parse response as JSON: '%s'", response.rawBody.c_str());
+                }
             }
 
             amx_Push(currentAmx, id);

--- a/test.pwn
+++ b/test.pwn
@@ -226,6 +226,34 @@ Test:InvalidClient() {
 
 
 // -
+// RequestJSON - empty response body
+// -
+
+
+new Request:OnEmptyJson_ID;
+Test:EmptyJsonResponse() {
+    new RequestsClient:client = RequestsClient("http://httpbin.org/", RequestHeaders());
+    OnEmptyJson_ID = RequestJSON(
+        client,
+        "status/204",
+        HTTP_METHOD_POST,
+        "OnEmptyJson",
+        JsonObject("content", JsonString("hello")),
+        .headers = RequestHeaders()
+    );
+}
+forward OnEmptyJson(Request:id, E_HTTP_STATUS:status, Node:node);
+public OnEmptyJson(Request:id, E_HTTP_STATUS:status, Node:node) {
+    print("*** Test OnEmptyJson\n");
+
+    ASSERT(id == OnEmptyJson_ID);
+    ASSERT(status == HTTP_STATUS_NO_CONTENT);
+
+    print("\nPASS!");
+}
+
+
+// -
 // WebSocket Tests
 // -
 


### PR DESCRIPTION
## Problem

Endpoints such as Discord webhooks reply with an **empty body** (commonly a `204 No Content`) on success. `RequestJSON` unconditionally ran the response body through `json::value::parse`, which throws on an empty string. The result was a spurious error logged on every successful no-content request:

```
ERROR: failed to parse response as JSON: ''
```

even though the request itself succeeded (the Discord message was posted). This is the behaviour reported in #57.

## Fix

In `processTick`, when the response body is empty it is now handed to the callback as a **null JSON node** instead of being parsed. Genuinely malformed *non-empty* bodies still log the parse error exactly as before, so real error reporting is preserved.

The HTTP status code is still passed through, so users can check e.g. `HTTP_STATUS_NO_CONTENT` in their callback.

## Test

Added `EmptyJsonResponse` in `test.pwn` which POSTs to `httpbin.org/status/204` (returns 204 with no body) and asserts the callback fires with `HTTP_STATUS_NO_CONTENT`. The full suite passes (55 tests) and no parse error is logged.

Fixes #57